### PR TITLE
Feat: add pycryptodomex fallback for certificate-chain / authenticity validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,21 @@ There are a wide range of available commands, each with their own relevant optio
 
 _There are also some general tools, such as those required to decrypt encrypted Seedkeeper JSON backups. (These can be accessed either standalone or via the module)_
 
+### Card Authenticity Check
+
+Use the `common-verify-authenticity` command to verify that the connected card was issued by Satochip:
+
+```
+satochip-cli common-verify-authenticity
+```
+
+By default the command relies on OpenSSL for certificate validation. If OpenSSL is not available, it falls back to a pure Python implementation using `pycryptodomex`. You can force a specific backend with the `--backend` option, choosing between `auto`, `openssl`, or `pycryptodomex`:
+
+```
+satochip-cli common-verify-authenticity --backend pycryptodomex
+```
+
+
 More details about the `satochip-cli` [here](https://github.com/Toporin/pysatochip/blob/master/README-CLI.md).
 
 ## Running from Source

--- a/pysatochip/CardConnector.py
+++ b/pysatochip/CardConnector.py
@@ -3338,7 +3338,7 @@ class CardConnector:
         
         return verif;
     
-    def card_verify_authenticity(self):
+    def card_verify_authenticity(self, backend: str = "auto"):
         logger.debug('In card_verify_authenticity')
         
         # get certificate from device
@@ -3362,7 +3362,7 @@ class CardConnector:
             return False, txt_ca, txt_subca, txt_device, txt_error
 
         # Perform some checks on the certificate
-        validator = CertificateValidator()
+        validator = CertificateValidator(backend=backend)
 
         # Check that the certificate subject matches the device serial number
         cert_dict =  validator.parse_pem_certificate(cert_pem)

--- a/pysatochip/certificate_validator.py
+++ b/pysatochip/certificate_validator.py
@@ -1,17 +1,28 @@
-import sys
-import os 
-import logging 
-#from OpenSSL.crypto import load_certificate, load_privatekey
-#from OpenSSL.crypto import X509Store, X509StoreContext
-import OpenSSL
+import os
+import logging
+
+try:
+    import OpenSSL
+    HAS_OPENSSL = True
+except Exception:  # pragma: no cover - optional dependency
+    OpenSSL = None
+    HAS_OPENSSL = False
 
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 class CertificateValidator:
-   
-    def __init__(self, loglevel= logging.WARNING):
+    """Validate device certificate chains using OpenSSL or pure Python."""
+
+    def __init__(self, backend: str = "auto", loglevel: int = logging.WARNING):
+        """Create a validator.
+
+        :param backend: ``'openssl'``, ``'pycryptodomex'`` or ``'auto'``.
+            In ``auto`` mode OpenSSL is used when available.
+        :param loglevel: logger verbosity
+        """
+        self.backend = backend
         logger.setLevel(loglevel)
         logger.debug("In __init__")
     
@@ -76,154 +87,235 @@ class CertificateValidator:
         with open(path_subca, 'r', encoding='utf-8') as f:
                     subca_pem = f.read()
                     #logger.debug("SUBCA pem: " + subca_pem)
-        
-        try:
-            parsed_ca = OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_PEM, ca_pem)
-            txt_ca= OpenSSL.crypto.dump_certificate(OpenSSL.crypto.FILETYPE_TEXT, parsed_ca).decode("utf-8")
-            logger.debug("CA cert: " + txt_ca)
-            parsed_subca = OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_PEM, subca_pem)
-            txt_subca= OpenSSL.crypto.dump_certificate(OpenSSL.crypto.FILETYPE_TEXT, parsed_subca).decode("utf-8")
-            logger.debug("SUBCA cert: " + txt_subca)
-            parsed_device = OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_PEM, device_pem)
-            txt_device= OpenSSL.crypto.dump_certificate(OpenSSL.crypto.FILETYPE_TEXT, parsed_device).decode("utf-8")
-            logger.debug("DEVICE cert: " + txt_device)
-        except OpenSSL.crypto.Error as ex:
-            txt_error= "Exception during pem certificates parsing: "+ str(ex)
+
+        use_openssl = HAS_OPENSSL and self.backend != "pycryptodomex"
+        if self.backend == "openssl" and not HAS_OPENSSL:
+            txt_error = "OpenSSL backend requested but pyOpenSSL is not available"
             return False, device_pubkey, txt_ca, txt_subca, txt_device, txt_error
-        
-        # extract pubkey from device certificate
-        device_pkey= parsed_device.get_pubkey()
-        device_pkey_asn1= OpenSSL.crypto.dump_publickey(OpenSSL.crypto.FILETYPE_ASN1, device_pkey)
-        logger.debug("DEVICE pubkey asn1: " + device_pkey_asn1.hex())
-        device_pubkey= device_pkey_asn1[-65:]
-        
-        # add ca in store
-        store = OpenSSL.crypto.X509Store()
-        store.add_cert(parsed_ca)
-        
-        try:
-            # Check the chain certificate before adding it to the store.
-            store_ctx = OpenSSL.crypto.X509StoreContext(store, parsed_subca)
-            store_ctx.verify_certificate()
-            store.add_cert(parsed_subca)
-        except OpenSSL.crypto.X509StoreContextError as ex:
-            txt_error= "Exception during subca validation: "+ str(ex)
-            return False, device_pubkey, txt_ca, txt_subca, txt_device, txt_error
-            
-        try:
-            # Now check the end-entity certificate.
-            store_ctx = OpenSSL.crypto.X509StoreContext(store, parsed_device)
-            store_ctx.verify_certificate()
-        except OpenSSL.crypto.X509StoreContextError as ex:
-            txt_error= "Exception during device certificate validation: "+ str(ex)
-            return False, device_pubkey, txt_ca, txt_subca, txt_device, txt_error
-        
-        # if use_test:
-            # txt_error= "WARNING: Chain certificate validated with TEST CA! NOT FOR PRODUCTION!"
-            # return False, device_pubkey, txt_ca, txt_subca, txt_device, txt_error
-        
-        return True, device_pubkey, txt_ca, txt_subca, txt_device, txt_error
-    
-    def validate_certificate_chain_old(self, device_pem, device_type):
-        logger.debug("In validate_certificate_chain")
-        
-        txt_ca=txt_subca=txt_device=txt_error=""
-        device_pubkey= bytes(65*[0])
-        
-        # load subca according to device type
-        directory=os.path.join(os.path.dirname(__file__), "cert")
-        path_ca = os.path.join(directory, 'ca.cert')
-        if device_type=="SeedKeeper":
-            path_subca = os.path.join(directory, 'subca-seedkeeper.cert')
-        elif device_type=="Satochip":
-            path_subca = os.path.join(directory, 'subca-satochip.cert')
-        elif device_type=="Satodime":
-            path_subca = os.path.join(directory, 'subca-satodime.cert')
+
+        if use_openssl:
+            try:
+                parsed_ca = OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_PEM, ca_pem)
+                txt_ca= OpenSSL.crypto.dump_certificate(OpenSSL.crypto.FILETYPE_TEXT, parsed_ca).decode("utf-8")
+                logger.debug("CA cert: " + txt_ca)
+                parsed_subca = OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_PEM, subca_pem)
+                txt_subca= OpenSSL.crypto.dump_certificate(OpenSSL.crypto.FILETYPE_TEXT, parsed_subca).decode("utf-8")
+                logger.debug("SUBCA cert: " + txt_subca)
+                parsed_device = OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_PEM, device_pem)
+                txt_device= OpenSSL.crypto.dump_certificate(OpenSSL.crypto.FILETYPE_TEXT, parsed_device).decode("utf-8")
+                logger.debug("DEVICE cert: " + txt_device)
+            except OpenSSL.crypto.Error as ex:
+                txt_error= "Exception during pem certificates parsing: "+ str(ex)
+                return False, device_pubkey, txt_ca, txt_subca, txt_device, txt_error
+
+            # extract pubkey from device certificate
+            device_pkey= parsed_device.get_pubkey()
+            device_pkey_asn1= OpenSSL.crypto.dump_publickey(OpenSSL.crypto.FILETYPE_ASN1, device_pkey)
+            logger.debug("DEVICE pubkey asn1: " + device_pkey_asn1.hex())
+            device_pubkey= device_pkey_asn1[-65:]
+
+            # add ca in store
+            store = OpenSSL.crypto.X509Store()
+            store.add_cert(parsed_ca)
+
+            try:
+                # Check the chain certificate before adding it to the store.
+                store_ctx = OpenSSL.crypto.X509StoreContext(store, parsed_subca)
+                store_ctx.verify_certificate()
+                store.add_cert(parsed_subca)
+            except OpenSSL.crypto.X509StoreContextError as ex:
+                txt_error= "Exception during subca validation: "+ str(ex)
+                return False, device_pubkey, txt_ca, txt_subca, txt_device, txt_error
+
+            try:
+                # Now check the end-entity certificate.
+                store_ctx = OpenSSL.crypto.X509StoreContext(store, parsed_device)
+                store_ctx.verify_certificate()
+            except OpenSSL.crypto.X509StoreContextError as ex:
+                txt_error= "Exception during device certificate validation: "+ str(ex)
+                return False, device_pubkey, txt_ca, txt_subca, txt_device, txt_error
+
+            # if use_test:
+                # txt_error= "WARNING: Chain certificate validated with TEST CA! NOT FOR PRODUCTION!"
+                # return False, device_pubkey, txt_ca, txt_subca, txt_device, txt_error
+
+            return True, device_pubkey, txt_ca, txt_subca, txt_device, txt_error
         else:
-            txt_error= "Unknown card_type: "+ str(device_type)
-            return False, device_pubkey, txt_ca, txt_subca, txt_device, txt_error
-        
-        # for testing purpose only!
-        TEST=False
-        if TEST:
-            #path_ca = os.path.join(directory, 'bad-ca.cert') #for testing purpose!
-            path_ca = os.path.join(directory, 'test-ca.cert') #for testing purpose!
-            path_subca = os.path.join(directory, 'test-subca-seedkeeper.cert') #for testing purpose! 
-            
-        # todo: FileNotFoundError
-        with open(path_ca, 'r', encoding='utf-8') as f:
-                    ca_pem = f.read()
-                    #logger.debug("CA pem: " + ca_pem)
-        with open(path_subca, 'r', encoding='utf-8') as f:
-                    subca_pem = f.read()
-                    #logger.debug("SUBCA pem: " + subca_pem)
-        
+            return self._validate_chain_pycryptodomex(ca_pem, subca_pem, device_pem)
+
+    def _validate_chain_pycryptodomex(self, ca_pem, subca_pem, device_pem):
+        txt_ca = txt_subca = txt_device = "OpenSSL module not available"
+        device_pubkey = bytes(65 * [0])
         try:
-            parsed_ca = OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_PEM, ca_pem)
-            txt_ca= OpenSSL.crypto.dump_certificate(OpenSSL.crypto.FILETYPE_TEXT, parsed_ca).decode("utf-8")
-            logger.debug("CA cert: " + txt_ca)
-            parsed_subca = OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_PEM, subca_pem)
-            txt_subca= OpenSSL.crypto.dump_certificate(OpenSSL.crypto.FILETYPE_TEXT, parsed_subca).decode("utf-8")
-            logger.debug("SUBCA cert: " + txt_subca)
-            parsed_device = OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_PEM, device_pem)
-            txt_device= OpenSSL.crypto.dump_certificate(OpenSSL.crypto.FILETYPE_TEXT, parsed_device).decode("utf-8")
-            logger.debug("DEVICE cert: " + txt_device)
-        except OpenSSL.crypto.Error as ex:
-            txt_error= "Exception during pem certificates parsing: "+ str(ex)
+            from Cryptodome.Util.asn1 import DerSequence, DerSetOf, DerObjectId, DerBitString, DerObject
+            from Cryptodome.Hash import SHA256, SHA384, SHA512
+            from ecdsa import VerifyingKey, NIST384p, SECP256k1, util
+            import re, base64
+            from datetime import datetime
+
+            HASHES = {
+                '1.2.840.10045.4.3.2': SHA256,
+                '1.2.840.10045.4.3.3': SHA384,
+                '1.2.840.10045.4.3.4': SHA512,
+            }
+            CURVES = {
+                '1.3.132.0.10': SECP256k1,
+                '1.3.132.0.34': NIST384p,
+                '1.2.840.10045.3.1.7': None,
+            }
+
+            def der_from_pem(pem):
+                m = re.search(r"-----BEGIN CERTIFICATE-----\s*(.*?)\s*-----END CERTIFICATE-----", pem, re.S)
+                if not m:
+                    raise ValueError("Invalid PEM certificate")
+                return base64.b64decode(''.join(m.group(1).split()))
+
+            OID_NAMES = {
+                '2.5.4.3': b'CN',
+                '2.5.4.6': b'C',
+                '2.5.4.10': b'O',
+                '2.5.4.11': b'OU',
+                '2.5.4.7': b'L',
+                '2.5.4.8': b'ST',
+                '1.2.840.113549.1.9.1': b'emailAddress',
+            }
+
+            def parse_name(der):
+                seq = DerSequence(); seq.decode(der)
+                attrs = {}
+                for rdn in seq:
+                    set_seq = DerSetOf(); set_seq.decode(rdn)
+                    attr_seq = DerSequence(); attr_seq.decode(set_seq[0])
+                    oid = DerObjectId(); oid.decode(attr_seq[0])
+                    value_obj = DerObject(); value_obj.decode(attr_seq[1])
+                    key = OID_NAMES.get(oid.value, oid.value.encode())
+                    attrs[key] = value_obj.payload.decode('utf-8').encode()
+                return attrs
+
+            def parse_cert(pem):
+                der = der_from_pem(pem)
+                seq = DerSequence(); seq.decode(der)
+                tbs_der = seq[0]
+                sig_seq = DerSequence(); sig_seq.decode(seq[1])
+                oid = DerObjectId(); oid.decode(sig_seq[0])
+                sig_oid = oid.value
+                sig_bit = DerBitString(); sig_bit.decode(seq[2])
+                sig_der = sig_bit.value
+                tbs_seq = DerSequence(); tbs_seq.decode(tbs_der)
+                issuer = parse_name(tbs_seq[3])
+                validity_seq = DerSequence(); validity_seq.decode(tbs_seq[4])
+                not_after_obj = DerObject(); not_after_obj.decode(validity_seq[1])
+                na = not_after_obj.payload.decode('utf-8')
+                if len(na) == 13:
+                    expiry = datetime.strptime(na, "%y%m%d%H%M%SZ")
+                else:
+                    expiry = datetime.strptime(na, "%Y%m%d%H%M%SZ")
+                subject = parse_name(tbs_seq[5])
+                spki_seq = DerSequence(); spki_seq.decode(tbs_seq[6])
+                algo_seq = DerSequence(); algo_seq.decode(spki_seq[0])
+                curve_oid = None
+                if len(algo_seq) > 1:
+                    curve_oid_obj = DerObjectId(); curve_oid_obj.decode(algo_seq[1])
+                    curve_oid = curve_oid_obj.value
+                pub_bit = DerBitString(); pub_bit.decode(spki_seq[1])
+                pub_bytes = pub_bit.value
+                is_expired = datetime.utcnow() > expiry
+                return {
+                    'tbs': tbs_der,
+                    'sig': sig_der,
+                    'sig_oid': sig_oid,
+                    'pub_bytes': pub_bytes,
+                    'curve_oid': curve_oid,
+                    'issuer': issuer,
+                    'subject': subject,
+                    'is_expired': is_expired,
+                }
+
+            def verify_cert(issuer_pub_bytes, issuer_curve, cert_info):
+                vk = VerifyingKey.from_string(issuer_pub_bytes[1:], curve=issuer_curve)
+                hmod = HASHES[cert_info['sig_oid']]
+                vk.verify(cert_info['sig'], cert_info['tbs'], hashfunc=lambda x, hm=hmod: hm.new(x), sigdecode=util.sigdecode_der)
+
+            def pubkey_curve(cert_info):
+                curve = CURVES.get(cert_info['curve_oid'])
+                return cert_info['pub_bytes'], curve
+
+            ca_info = parse_cert(ca_pem)
+            ca_pub, ca_curve = pubkey_curve(ca_info)
+            subca_info = parse_cert(subca_pem)
+            verify_cert(ca_pub, ca_curve, subca_info)
+            subca_pub, subca_curve = pubkey_curve(subca_info)
+            device_info = parse_cert(device_pem)
+            verify_cert(subca_pub, subca_curve, device_info)
+            device_pubkey = device_info['pub_bytes']
+            return True, device_pubkey, txt_ca, txt_subca, txt_device, ""
+        except Exception as ex:
+            txt_error = str(ex)
             return False, device_pubkey, txt_ca, txt_subca, txt_device, txt_error
-        
-        # extract pubkey from device certificate
-        device_pkey= parsed_device.get_pubkey()
-        device_pkey_asn1= OpenSSL.crypto.dump_publickey(OpenSSL.crypto.FILETYPE_ASN1, device_pkey)
-        logger.debug("DEVICE pubkey asn1: " + device_pkey_asn1.hex())
-        device_pubkey= device_pkey_asn1[-65:]
-        
-        # add ca in store
-        store = OpenSSL.crypto.X509Store()
-        store.add_cert(parsed_ca)
-        
-        try:
-            # Check the chain certificate before adding it to the store.
-            store_ctx = OpenSSL.crypto.X509StoreContext(store, parsed_subca)
-            store_ctx.verify_certificate()
-            store.add_cert(parsed_subca)
-        except OpenSSL.crypto.X509StoreContextError as ex:
-            txt_error= "Exception during subca validation: "+ str(ex)
-            return False, device_pubkey, txt_ca, txt_subca, txt_device, txt_error
-            
-        try:
-            # Now check the end-entity certificate.
-            store_ctx = OpenSSL.crypto.X509StoreContext(store, parsed_device)
-            store_ctx.verify_certificate()
-        except OpenSSL.crypto.X509StoreContextError as ex:
-            txt_error= "Exception during device certificate validation: "+ str(ex)
-            return False, device_pubkey, txt_ca, txt_subca, txt_device, txt_error
-        
-        if TEST:
-            txt_error= "WARNING: Chain certificate validated with TEST CA! NOT FOR PRODUCTION!"
-            return False, device_pubkey, txt_ca, txt_subca, txt_device, txt_error
-        
-        return True, device_pubkey, txt_ca, txt_subca, txt_device, txt_error
-        
     def parse_pem_certificate(self, cert_pem):
-    
-        cert_dict= {}
-        cert_x509 = OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_PEM, cert_pem)
-        # https://www.pyopenssl.org/en/stable/api/crypto.html#x509-objects
-        # get_notAfter()
-        # get_notBefore()
-        # get_pubkey()
-        # get_serial_number()
-        # get_signature_algorithm()
-        issuer= cert_x509.get_issuer()
-        subject= cert_x509.get_subject()
-        is_expired= cert_x509.has_expired()
-        
-        cert_dict['is_expired']=is_expired
-        issuer_dict= dict(issuer.get_components())
-        cert_dict['issuer']= issuer_dict
-        subject_dict= dict(subject.get_components())
-        cert_dict['subject']= subject_dict
-        
-        return cert_dict
+        """Parse a PEM certificate and return basic fields."""
+
+        if self.backend == "openssl":
+            if not HAS_OPENSSL:
+                raise RuntimeError("OpenSSL backend requested but pyOpenSSL is not available")
+        if HAS_OPENSSL and self.backend != "pycryptodomex":
+            cert_dict = {}
+            cert_x509 = OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_PEM, cert_pem)
+            issuer = cert_x509.get_issuer()
+            subject = cert_x509.get_subject()
+            cert_dict['is_expired'] = cert_x509.has_expired()
+            cert_dict['issuer'] = dict(issuer.get_components())
+            cert_dict['subject'] = dict(subject.get_components())
+            return cert_dict
+
+        return self._parse_pem_certificate_pycryptodomex(cert_pem)
+
+    def _parse_pem_certificate_pycryptodomex(self, cert_pem):
+        from Cryptodome.Util.asn1 import DerSequence, DerSetOf, DerObjectId, DerObject
+        import base64, re
+        from datetime import datetime
+
+        OID_NAMES = {
+            '2.5.4.3': b'CN',
+            '2.5.4.6': b'C',
+            '2.5.4.10': b'O',
+            '2.5.4.11': b'OU',
+            '2.5.4.7': b'L',
+            '2.5.4.8': b'ST',
+            '1.2.840.113549.1.9.1': b'emailAddress',
+        }
+
+        def der_from_pem(pem):
+            m = re.search(r"-----BEGIN CERTIFICATE-----\s*(.*?)\s*-----END CERTIFICATE-----", pem, re.S)
+            if not m:
+                raise ValueError("Invalid PEM certificate")
+            return base64.b64decode(''.join(m.group(1).split()))
+
+        def parse_name(der):
+            seq = DerSequence(); seq.decode(der)
+            attrs = {}
+            for rdn in seq:
+                set_seq = DerSetOf(); set_seq.decode(rdn)
+                attr_seq = DerSequence(); attr_seq.decode(set_seq[0])
+                oid = DerObjectId(); oid.decode(attr_seq[0])
+                value_obj = DerObject(); value_obj.decode(attr_seq[1])
+                key = OID_NAMES.get(oid.value, oid.value.encode())
+                attrs[key] = value_obj.payload.decode('utf-8').encode()
+            return attrs
+
+        der = der_from_pem(cert_pem)
+        seq = DerSequence(); seq.decode(der)
+        tbs_der = seq[0]
+        tbs_seq = DerSequence(); tbs_seq.decode(tbs_der)
+        issuer = parse_name(tbs_seq[3])
+        validity_seq = DerSequence(); validity_seq.decode(tbs_seq[4])
+        not_after_obj = DerObject(); not_after_obj.decode(validity_seq[1])
+        na = not_after_obj.payload.decode('utf-8')
+        if len(na) == 13:
+            expiry = datetime.strptime(na, "%y%m%d%H%M%SZ")
+        else:
+            expiry = datetime.strptime(na, "%Y%m%d%H%M%SZ")
+        subject = parse_name(tbs_seq[5])
+        is_expired = datetime.utcnow() > expiry
+        return {'issuer': issuer, 'subject': subject, 'is_expired': is_expired}
         

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,6 @@ ecdsa>=0.15
 pyaes>=1.6.1
 cryptography>=3.3.2
 pyopenssl>=20.0.0 # for certificate chain validation
+pycryptodomex>=3.18 # fallback when OpenSSL is unavailable
 certifi
+

--- a/satochip_cli.py
+++ b/satochip_cli.py
@@ -589,7 +589,8 @@ def common_import_ndef_authentikey(privkey):
         print(e)
 
 @main.command()
-def common_verify_authenticity():
+@click.option("--backend", type=click.Choice(["auto", "openssl", "pycryptodomex"]), default="auto", help="Certificate validation backend")
+def common_verify_authenticity(backend):
     if cc.card_get_status()[3]['setup_done'] == False:
         print("Unable to perform this function until setup is complete")
         return
@@ -607,7 +608,7 @@ def common_verify_authenticity():
                 pin = getpass("Enter your PIN:")
             cc.card_verify_PIN(pin)
 
-        is_authentic, txt_ca, txt_subca, txt_device, txt_error = cc.card_verify_authenticity()
+        is_authentic, txt_ca, txt_subca, txt_device, txt_error = cc.card_verify_authenticity(backend=backend)
         print("Card is authentic:", is_authentic)
         print("CA Cert:", txt_ca)
         print("SubCA Cert:", txt_subca)


### PR DESCRIPTION
Some environments (e.g. embedded/SeedSigner-style setups) do not have OpenSSL/pyOpenSSL available, making `common-verify-authenticity` unusable.

`certificate_validator.py` now tries OpenSSL first and falls back to a pure-Python implementation using `pycryptodomex` + `ecdsa`. A new `--backend` CLI option lets callers force `auto` (default), `openssl`, or `pycryptodomex`.

`requirements.txt` adds `pycryptodomex>=3.18` and `README.md` documents the option.